### PR TITLE
Added needed imports to sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ _**Note:** This will also import some [vapor/redis](https://github.com/vapor/red
 #### Create a client and a queue:
 
 ```
+import Redis
+import Reswifq
+import VaporRedisClient
+
 let client = VaporRedisClient(try TCPClient(hostname: "127.0.0.1", port: 6379))
 
 let queue = Reswifq(client: client)


### PR DESCRIPTION
I lost 20 minutes of my life wondering why `try TCPClient(hostname: "127.0.0.1", port: 6379)` was failing until I realized it was in the Redis dependency ;)